### PR TITLE
Allow to specify additional Docker args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,3 +157,18 @@ jobs:
           dpkg --contents debian/artifacts/test_1_amd64.deb | grep ./usr/bin/mybin
           test -f debian/artifacts/test_1_amd64.buildinfo
           test -f debian/artifacts/test_1_amd64.changes
+
+  extra-docker-args:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cat test/Makefile_extra-docker-args >> test/Makefile
+      - uses: ./
+        env: 
+          DEB_BUILD_OPTIONS: noautodbgsym
+        with:
+          buildpackage-opts: --build=binary --no-sign
+          source-dir: test
+          extra-docker-args: --add-host extra-args-test:127.0.0.1
+      - run: |
+          test "$(ls -1 debian/artifacts/*.deb | wc -l)" = 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,14 +113,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: cat test/Makefile_extra-docker-args >> test/Makefile
       - uses: ./
-        env: 
+        env:
           DEB_BUILD_OPTIONS: noautodbgsym
         with:
           buildpackage-opts: --build=binary --no-sign
           source-dir: test
           extra-docker-args: --add-host extra-args-test:127.0.0.1
       - run: |
-          test "$(ls -1 debian/artifacts/*.deb | wc -l)" = 1
           dpkg --info debian/artifacts/test_1_amd64.deb
           dpkg --contents debian/artifacts/test_1_amd64.deb | grep ./usr/bin/mybin
           test -f debian/artifacts/test_1_amd64.buildinfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,25 @@ jobs:
           test -f debian/artifacts/test_1_amd64.buildinfo
           test -f debian/artifacts/test_1_amd64.changes
 
+  extra-docker-args:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cat test/Makefile_extra-docker-args >> test/Makefile
+      - uses: ./
+        env: 
+          DEB_BUILD_OPTIONS: noautodbgsym
+        with:
+          buildpackage-opts: --build=binary --no-sign
+          source-dir: test
+          extra-docker-args: --add-host extra-args-test:127.0.0.1
+      - run: |
+          test "$(ls -1 debian/artifacts/*.deb | wc -l)" = 1
+          dpkg --info debian/artifacts/test_1_amd64.deb
+          dpkg --contents debian/artifacts/test_1_amd64.deb | grep ./usr/bin/mybin
+          test -f debian/artifacts/test_1_amd64.buildinfo
+          test -f debian/artifacts/test_1_amd64.changes
+
   local-dockerfile:
     runs-on: ubuntu-latest
     steps:
@@ -157,18 +176,3 @@ jobs:
           dpkg --contents debian/artifacts/test_1_amd64.deb | grep ./usr/bin/mybin
           test -f debian/artifacts/test_1_amd64.buildinfo
           test -f debian/artifacts/test_1_amd64.changes
-
-  extra-docker-args:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: cat test/Makefile_extra-docker-args >> test/Makefile
-      - uses: ./
-        env: 
-          DEB_BUILD_OPTIONS: noautodbgsym
-        with:
-          buildpackage-opts: --build=binary --no-sign
-          source-dir: test
-          extra-docker-args: --add-host extra-args-test:127.0.0.1
-      - run: |
-          test "$(ls -1 debian/artifacts/*.deb | wc -l)" = 1

--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@ Dockerfile in GITHUB_WORKSPACE to build a container from.
 
 Defaults to `debian:stable-slim`.
 
-#### `extra-docker-args`
-Additional command line arguments passed to Docker container execution. This
-might be needed if specific volumes or network settings are required.
-
-*NOTE*: this will not override the action's default arguments.
-
-Optional and empty by default.
-
 #### `extra-build-deps`
 Extra packages to be installed as “build dependencies”. *This should rarely be
 used, build dependencies should be specified in the `debian/control` file.*
@@ -68,6 +60,13 @@ used, build dependencies should be specified in the `debian/control` file.*
 By default, these packages are installed without their recommended
 dependencies. To change this, pass `--install-recommends` in
 [`apt-opts`](#apt-opts).
+
+Optional and empty by default.
+
+#### `extra-docker-args`
+Additional command-line arguments passed to `docker run` when the build
+container is started. This might be needed if specific volumes or network
+settings are required.
 
 Optional and empty by default.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Dockerfile in GITHUB_WORKSPACE to build a container from.
 
 Defaults to `debian:stable-slim`.
 
+#### `extra-docker-args`
+Additional command line arguments passed to Docker container execution. This
+might be needed if specific volumes or network settings are required.
+
+*NOTE*: this will not override the action's default arguments.
+
+Optional and empty by default.
+
 #### `extra-build-deps`
 Extra packages to be installed as “build dependencies”. *This should rarely be
 used, build dependencies should be specified in the `debian/control` file.*

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
     default: debian:stable-slim
     description: Name of a Docker image to build inside or path of a Dockerfile
     required: true
+  extra-docker-args:
+    description: Additional arguments to 'docker run' of build container
+    required: false
   extra-build-deps:
     description: Extra packages to be installed as build dependencies
     required: false
@@ -37,6 +40,7 @@ runs:
         INPUT_BUILDPACKAGE_OPTS: ${{ inputs.buildpackage-opts }}
         INPUT_HOST_ARCH: ${{ inputs.host-arch }}
         INPUT_DOCKER_IMAGE: ${{ inputs.docker-image }}
+        INPUT_EXTRA_DOCKER_ARGS: ${{ inputs.extra-docker-args }}
         INPUT_EXTRA_BUILD_DEPS: ${{ inputs.extra-build-deps }}
         INPUT_SOURCE_DIR: ${{ inputs.source-dir }}
       run: ${{ github.action_path }}/scripts/run.sh

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: Extra packages to be installed as build dependencies
     required: false
   extra-docker-args:
-    description: Additional arguments to 'docker run' of build container
+    description: Additional arguments to 'docker run' when starting the build container
     required: false
   host-arch:
     description: Foreign architecture to setup cross-compilation for

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,11 @@ inputs:
     default: debian:stable-slim
     description: Name of a Docker image to build inside or path of a Dockerfile
     required: true
-  extra-docker-args:
-    description: Additional arguments to 'docker run' of build container
-    required: false
   extra-build-deps:
     description: Extra packages to be installed as build dependencies
+    required: false
+  extra-docker-args:
+    description: Additional arguments to 'docker run' of build container
     required: false
   host-arch:
     description: Foreign architecture to setup cross-compilation for
@@ -40,8 +40,8 @@ runs:
         INPUT_BUILDPACKAGE_OPTS: ${{ inputs.buildpackage-opts }}
         INPUT_HOST_ARCH: ${{ inputs.host-arch }}
         INPUT_DOCKER_IMAGE: ${{ inputs.docker-image }}
-        INPUT_EXTRA_DOCKER_ARGS: ${{ inputs.extra-docker-args }}
         INPUT_EXTRA_BUILD_DEPS: ${{ inputs.extra-build-deps }}
+        INPUT_EXTRA_DOCKER_ARGS: ${{ inputs.extra-docker-args }}
         INPUT_SOURCE_DIR: ${{ inputs.source-dir }}
       run: ${{ github.action_path }}/scripts/run.sh
       shell: bash

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -76,7 +76,7 @@ fi
 start_group "Starting build container"
 env > "$env_file"
 container_id=$(docker run \
-	--detach \
+	$INPUT_EXTRA_DOCKER_ARGS --detach \
 	--env-file="$env_file" \
 	--env=GITHUB_ACTION_PATH=/github/action \
 	--env=GITHUB_WORKSPACE=/github/workspace \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -76,7 +76,8 @@ fi
 start_group "Starting build container"
 env > "$env_file"
 container_id=$(docker run \
-	$INPUT_EXTRA_DOCKER_ARGS --detach \
+	$INPUT_EXTRA_DOCKER_ARGS \
+	--detach \
 	--env-file="$env_file" \
 	--env=GITHUB_ACTION_PATH=/github/action \
 	--env=GITHUB_WORKSPACE=/github/workspace \

--- a/test/Makefile_extra-docker-args
+++ b/test/Makefile_extra-docker-args
@@ -1,0 +1,11 @@
+
+.PHONY: test
+EXTRA_ARG_IP := $(shell grep extra-args-test /etc/hosts | awk '{print $$1}')
+
+test:
+	$(info $$EXTRA_ARG_IP = $(EXTRA_ARG_IP))
+ifeq ($(EXTRA_ARG_IP),127.0.0.1)
+	$(info Found extra Docker arg in /etc/hosts with value $(EXTRA_ARG_IP))
+else
+	$(error Expected Docker extra argument not found)
+endif

--- a/test/Makefile_extra-docker-args
+++ b/test/Makefile_extra-docker-args
@@ -1,11 +1,4 @@
 
 .PHONY: test
-EXTRA_ARG_IP := $(shell grep extra-args-test /etc/hosts | awk '{print $$1}')
-
 test:
-	$(info $$EXTRA_ARG_IP = $(EXTRA_ARG_IP))
-ifeq ($(EXTRA_ARG_IP),127.0.0.1)
-	$(info Found extra Docker arg in /etc/hosts with value $(EXTRA_ARG_IP))
-else
-	$(error Expected Docker extra argument not found)
-endif
+	test "$$(awk '$$2 == "extra-args-test" { print $$1 }' /etc/hosts)" = "127.0.0.1"


### PR DESCRIPTION
This PR adds the ability to specify additional `docker run` arguments.

I have a use case where I am running tests that depend on a virtual CAN device configured on the host. In order for the tests to succeed, Docker must be executed with `--net=host`. I assume there are other scenarios where this could come in handy as well, e.g. add environment variables, mount volumes, etc.

The action's internal arguments can not be overridden by user config.