### PR TITLE
Add a way to set apt preferences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,6 +281,31 @@ jobs:
           test -f debian/artifacts/test_1_amd64.buildinfo
           test -f debian/artifacts/test_1_amd64.changes
 
+  extra-apt-preferences:
+    needs: [setup-hook]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cat test/Makefile_extra-preferences >>test/Makefile
+      - uses: ./
+        env:
+          DEB_BUILD_OPTIONS: noautodbgsym
+        with:
+          buildpackage-opts: --build=binary --no-sign
+          extra-apt-preferences: |
+            Package: *
+            Pin: origin deb.debian.org
+            Pin-Priority: 900
+          setup-hook: |
+            apt-get update # Called here manually only for testing purposes!
+            ! apt-cache policy | grep -B3 'origin deb.debian.org' | grep -q '900'
+          source-dir: test
+      - run: |
+          dpkg --info debian/artifacts/test_1_amd64.deb
+          dpkg --contents debian/artifacts/test_1_amd64.deb | grep ./usr/bin/mybin
+          test -f debian/artifacts/test_1_amd64.buildinfo
+          test -f debian/artifacts/test_1_amd64.changes
+
   full-build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ deb822 style, see
 
 Optional and empty by default.
 
+#### `extra-apt-preferences`
+Extra APT preferences to configure package priorities in the build environment.
+
+This allows you to pin packages from specific sources or set priorities to control
+package selection during installation or upgrades. The preferences should be
+provided in a format supported by APT, typically as entries in Package, Pin, and
+Pin-Priority fields. For more details, see `man apt_preferences`.
+
+Optional and empty by default.
+
 #### `extra-repo-keys`
 Extra keys for APT to trust in the build environment. Useful in combination
 with [`extra-repos`](#extra-repos).

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   extra-repos:
     description: Extra APT repositories to configure in the build environment (one-line-style or deb822-style format)
     required: false
+  extra-apt-preferences:
+    description: Extra APT preferences fragments file to configure the priorities between multiple feeds
+    required: false
   host-arch:
     description: Foreign architecture to setup cross-building for
     required: false
@@ -58,6 +61,7 @@ runs:
         INPUT_EXTRA_DOCKER_ARGS: ${{ inputs.extra-docker-args }}
         INPUT_EXTRA_REPO_KEYS: ${{  inputs.extra-repo-keys }}
         INPUT_EXTRA_REPOS: ${{  inputs.extra-repos }}
+        INPUT_EXTRA_APT_PREFERENCES: ${{  inputs.extra-apt-preferences }}
         INPUT_HOST_ARCH: ${{ inputs.host-arch }}
         INPUT_SETUP_HOOK: ${{ inputs.setup-hook }}
         INPUT_SOURCE_DIR: ${{ inputs.source-dir }}

--- a/scripts/install_build_deps
+++ b/scripts/install_build_deps
@@ -31,6 +31,8 @@ else
 fi
 printf "%s\n" "$INPUT_EXTRA_REPOS" >"/etc/apt/sources.list.d/build-deb-action${extra_repos_ext}"
 
+printf "%s\n" "$INPUT_EXTRA_APT_PREFERENCES" > "/etc/apt/preferences.d/extra-preferences.pref"
+
 apt-get update
 
 # shellcheck disable=SC2086

--- a/scripts/run
+++ b/scripts/run
@@ -115,6 +115,7 @@ env \
 	--unset=INPUT_BEFORE_BUILD_HOOK \
 	--unset=INPUT_EXTRA_REPO_KEYS \
 	--unset=INPUT_EXTRA_REPOS \
+	--unset=INPUT_EXTRA_APT_PREFERENCES \
 	--unset=INPUT_SETUP_HOOK \
 	>"$env_file"
 
@@ -127,6 +128,7 @@ container_id=$(
 		--env=GITHUB_ACTION_PATH=/github/action \
 		--env=GITHUB_WORKSPACE=/github/workspace \
 		--env=INPUT_EXTRA_REPOS \
+		--env=INPUT_EXTRA_APT_PREFERENCES \
 		--mount="type=bind,src=${GITHUB_ACTION_PATH},dst=/github/action,ro" \
 		--mount="type=bind,src=${build_dir},dst=/github/build" \
 		--mount="type=bind,src=${GITHUB_WORKSPACE},dst=/github/workspace" \

--- a/test/Makefile_extra-preferences
+++ b/test/Makefile_extra-preferences
@@ -1,0 +1,4 @@
+
+.PHONY: test
+test:
+	apt-cache policy | grep -B3 'origin deb.debian.org' | grep -q '900'


### PR DESCRIPTION
Hello,

this is a small-ish change that allows us to use apt preferences fragments [0].
Please feel free to either pull this change in or suggest changes if needed.

Thanks!

[0] https://manpages.ubuntu.com/manpages/bionic/man5/apt_preferences.5.html